### PR TITLE
Add support for new pump fun amm endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitnet = "0.31.9"
 serde_json = "1.0.132"
 solana-sdk = "2.1.0"
 solana-hash = "2.1.0"
-solana-trader-proto = "0.2.0"
+solana-trader-proto = "0.2.1"
 thiserror = "1.0.65"
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-tungstenite = { version = "0.24.0", features = ["rustls-tls-webpki-roots"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-trader-client-rust"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["support@bloxroute.com"]
 description = "Solana Trader API client implementation"

--- a/src/provider/grpc/stream.rs
+++ b/src/provider/grpc/stream.rs
@@ -6,6 +6,20 @@ use tonic::Streaming;
 use super::GrpcClient;
 
 impl GrpcClient {
+    pub async fn get_pump_fun_new_amm_pool_stream(
+        &mut self,
+    ) -> Result<Streaming<api::GetPumpFunNewAmmPoolStreamResponse>> {
+        let request = Request::new(api::GetPumpFunNewAmmPoolStreamRequest {});
+
+        let response = self
+            .client
+            .get_pump_fun_new_amm_pool_stream(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("GetPumpFunNewAmmPoolStream error: {}", e))?;
+
+        Ok(response.into_inner())
+    }
+    
     pub async fn get_prices_stream(
         &mut self,
         projects: Vec<api::Project>,

--- a/src/provider/ws/stream.rs
+++ b/src/provider/ws/stream.rs
@@ -4,6 +4,14 @@ use solana_trader_proto::api;
 use tokio_stream::Stream;
 
 impl WebSocketClient {
+    pub async fn get_pump_fun_new_amm_pool_stream(
+        &self,
+    ) -> Result<impl Stream<Item = Result<api::GetPumpFunNewAmmPoolStreamResponse>>> {
+        let request = api::GetPumpFunNewAmmPoolStreamRequest {};
+
+        self.conn.stream_proto("GetPumpFunNewAmmPoolStream", &request).await
+    }
+    
     pub async fn get_prices_stream(
         &self,
         projects: Vec<api::Project>,

--- a/tests/grpc/stream.rs
+++ b/tests/grpc/stream.rs
@@ -7,6 +7,28 @@ use solana_trader_proto::api;
 use test_case::test_case;
 use tokio_stream::StreamExt;
 
+#[test_case(1 ; "pump fun amm pool stream")]
+#[tokio::test]
+#[ignore]
+async fn test_pump_new_amm_pool(expected_pool: usize) -> Result<()> {
+    let mut client = GrpcClient::new(Some(MAINNET_PUMP_NY.to_string())).await?;
+    let mut stream = client.get_pump_fun_new_amm_pool_stream().await?;
+
+    println!("starting pump fun amm pool stream");
+
+    for pool_num in 1..=expected_pool {
+        let response = stream
+            .next()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Stream ended without data"))?
+            .map_err(|e| anyhow::anyhow!("Stream error: {}", e))?;
+
+        println!("New Pump Swap pool {} received: {:#?}", pool_num, response);
+    }
+
+    Ok(())
+}
+
 #[test_case(
     vec![api::Project::PRaydium],
     vec![WRAPPED_SOL.to_string()] ;

--- a/tests/ws/stream.rs
+++ b/tests/ws/stream.rs
@@ -7,6 +7,23 @@ use solana_trader_client_rust::{
 use solana_trader_proto::api;
 use test_case::test_case;
 
+#[tokio::test]
+#[ignore]
+async fn test_pump_fun_new_amm_pool_streams() -> Result<()> {
+    let ws = WebSocketClient::new(Some(MAINNET_PUMP_NY.to_string())).await?;
+    let mut stream = ws.get_pump_fun_new_amm_pool_stream().await?;
+
+    let response = stream
+        .next()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("Stream ended without data"))??;
+
+    println!("Response received: {:#?}", response);
+
+    ws.close().await?;
+    Ok(())
+}
+
 #[test_case(
     vec![api::Project::PRaydium],
     vec![WRAPPED_SOL.to_string()] ;


### PR DESCRIPTION
## Add support for the new Pump Fun AMM endpoint

- Edited the `src/provider/grpc/stream.rs` and `src/provider/ws/stream.rs` files with method receiver implementations on the `GrpcClient` and `WsClient` structs to add support for `get_pump_fun_new_amm_pool_stream`
- Added test cases for the new endpoint in `/tests/grpc/stream.rs` and `/tests/ws/stream.rs`
- Updated `Cargo.toml` to use the newly published proto crate containing the endpoint with `v0.2.1`
- Tests for the new endpoint passed with `REGION=NY NETWORK=MAINNET_PUMP cargo test stream::test_pump_new_amm_pool::pump_fun_amm_pool_stream -- --ignored --nocapture --test-threads=1`

*A new Rust crate will be deployed when merged to develop*