### PR TITLE
Added missing endpoints

### DIFF
--- a/src/provider/grpc/mod.rs
+++ b/src/provider/grpc/mod.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use rustls::crypto::ring::default_provider;
 use rustls::crypto::CryptoProvider;
 use solana_sdk::pubkey::Pubkey;
-use solana_trader_proto::api::{self, TransactionMessageV2};
+use solana_trader_proto::api::{self, GetServerTimeRequest, PostSubmitBatchRequest, TransactionMessageV2};
 use std::collections::HashMap;
 use tonic::service::Interceptor;
 use tonic::transport::ClientTlsConfig;
@@ -280,13 +280,52 @@ impl GrpcClient {
         &mut self,
         request: &api::GetRecentBlockHashRequest,
     ) -> Result<api::GetRecentBlockHashResponse> {
-        let response = self
+        let response: tonic::Response<api::GetRecentBlockHashResponse> = self
             .client
             .get_recent_block_hash(Request::new(*request))
             .await
             .map_err(|e| anyhow::anyhow!("GetRecentBlockHash error: {}", e))?;
 
         Ok(response.into_inner())
+    }
+
+    pub async fn get_server_time(
+        &mut self,
+        request: &GetServerTimeRequest,
+    ) -> Result<api::GetServerTimeResponse> {
+        let response: tonic::Response<api::GetServerTimeResponse> = self
+            .client
+            .get_server_time(Request::new(*request))
+            .await
+            .map_err(|e| anyhow::anyhow!("GetServerTime error: {}", e))?;
+
+        return Ok(response.into_inner())
+    }
+
+    pub async fn post_submit(
+        &mut self,
+        request: &PostSubmitRequest,
+    ) -> Result<api::PostSubmitResponse> {
+        let response: tonic::Response<api::PostSubmitResponse> = self
+            .client
+            .post_submit(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("PostSubmit error: {}", e))?;
+
+        return Ok(response.into_inner())
+    }
+
+    pub async fn post_submit_batch(
+        &mut self,
+        request: &PostSubmitBatchRequest,
+    ) -> Result<api::PostSubmitBatchResponse> {
+        let response: tonic::Response<api::PostSubmitBatchResponse> = self
+            .client
+            .post_submit_batch(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("PostSubmitBatch error: {}", e))?;
+
+        return Ok(response.into_inner())
     }
 
     pub async fn get_recent_block_hash_v2(

--- a/src/provider/grpc/quote.rs
+++ b/src/provider/grpc/quote.rs
@@ -44,6 +44,45 @@ impl GrpcClient {
         Ok(response.into_inner())
     }
 
+    pub async fn get_raydium_clmm_pools(
+        &mut self,
+        request: &api::GetRaydiumClmmPoolsRequest,
+    ) -> Result<api::GetRaydiumClmmPoolsResponse> {
+        let response = self
+            .client
+            .get_raydium_clmm_pools(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("GetRaydiumClmmPools error: {}", e))?;
+
+        Ok(response.into_inner())
+    }
+
+    pub async fn get_raydium_pool_reserve(
+        &mut self,
+        request: &api::GetRaydiumPoolReserveRequest,
+    ) -> Result<api::GetRaydiumPoolReserveResponse> {
+        let response = self
+            .client
+            .get_raydium_pool_reserve(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("GetRaydiumPoolReserve error: {}", e))?;
+
+        Ok(response.into_inner())
+    }
+
+    pub async fn get_raydium_pools(
+        &mut self,
+        request: &api::GetRaydiumPoolsRequest,
+    ) -> Result<api::GetRaydiumPoolsResponse> {
+        let response = self
+            .client
+            .get_raydium_pools(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("GetRaydiumPools error: {}", e))?;
+
+        Ok(response.into_inner())
+    }
+    
     pub async fn get_pump_fun_quotes(
         &mut self,
         request: &api::GetPumpFunQuotesRequest,

--- a/src/provider/grpc/stream.rs
+++ b/src/provider/grpc/stream.rs
@@ -171,6 +171,25 @@ impl GrpcClient {
         Ok(response.into_inner())
     }
 
+    pub async fn get_quotes_stream(
+        &mut self,
+        projects: Vec<i32>,
+        token_pairs: Vec<api::TokenPair>,
+    ) -> Result<Streaming<api::GetQuotesStreamResponse>> {
+        let request = Request::new(api::GetQuotesStreamRequest {
+            projects,
+            token_pairs,
+        });
+        
+        let response = self
+            .client
+            .get_quotes_stream(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("GetQuotesStream error: {}", e))?;
+        
+        Ok(response.into_inner())
+    }
+
     pub async fn get_new_raydium_pools_by_transaction_stream(
         &mut self,
     ) -> Result<Streaming<api::GetNewRaydiumPoolsByTransactionResponse>> {

--- a/src/provider/grpc/swap.rs
+++ b/src/provider/grpc/swap.rs
@@ -4,7 +4,7 @@ use solana_sdk::{
     message::{v0, VersionedMessage},
     transaction::VersionedTransaction,
 };
-use solana_trader_proto::api;
+use solana_trader_proto::api::{self, PostPumpFunSwapRequestSol};
 use tonic::Request;
 
 use crate::{
@@ -204,6 +204,19 @@ impl GrpcClient {
             .map_err(|e| anyhow::anyhow!("PostPumpFunSwap error: {}", e))?;
 
         Ok(response.into_inner())
+    }
+
+    pub async fn post_pump_fun_swap_sol(
+        &mut self,
+        request: &PostPumpFunSwapRequestSol,
+    ) -> Result<api::PostPumpFunSwapResponse> {
+        let response: tonic::Response<api::PostPumpFunSwapResponse> = self
+            .client
+            .post_pump_fun_swap_sol(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("PostPumpFunSwapSol error: {}", e))?;
+
+        return Ok(response.into_inner())
     }
 
     pub async fn post_trade_swap(

--- a/src/provider/http/mod.rs
+++ b/src/provider/http/mod.rs
@@ -179,6 +179,89 @@ impl HTTPClient {
         Ok(signatures)
     }
 
+    pub async fn post_submit_batch(
+        &self,
+        entries: Vec<api::PostSubmitRequestEntry>,
+        submit_strategy: api::SubmitStrategy,
+        use_bundle: Option<bool>,
+        front_running_protection: Option<bool>
+    ) -> anyhow::Result<api::PostSubmitBatchResponse> {
+        let url = format!("{}/api/v1/trade/submit-batch", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "entries": entries,
+            "submitStrategy": submit_strategy,
+            "useBundle": use_bundle,
+            "frontRunningProtection": front_running_protection
+        });
+        
+        let response = self
+            .client
+            .post(&url)
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostSubmitBatchResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
+    pub async fn post_submit_batch_v2(
+        &self,
+        entries: Vec<api::PostSubmitRequestEntry>,
+        submit_strategy: api::SubmitStrategy,
+        use_bundle: Option<bool>,
+        front_running_protection: Option<bool>
+    ) -> anyhow::Result<api::PostSubmitBatchResponse> {
+        let url = format!("{}/api/v2/submit-batch", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "entries": entries,
+            "submitStrategy": submit_strategy,
+            "useBundle": use_bundle,
+            "frontRunningProtection": front_running_protection
+        });
+        
+        let response = self
+            .client
+            .post(&url)
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostSubmitBatchResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
+    pub async fn post_submit_paladin_v2(
+        &self,
+        transaction: api::TransactionMessageV2,
+        revert_protection: Option<bool>
+    ) -> anyhow::Result<api::PostSubmitResponse> {
+        let url = format!("{}/api/v2/submit-paladin", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "transaction": transaction,
+            "revertProtection": revert_protection
+        });
+        
+        let response = self
+            .client
+            .post(&url)
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostSubmitResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
     pub async fn sign_and_submit_snipe<T: IntoTransactionMessage + Clone>(
         &self,
         txs: Vec<T>,
@@ -234,6 +317,70 @@ impl HTTPClient {
             .collect();
 
         Ok(signatures)
+    }
+
+    pub async fn post_submit_snipe_v2(
+        &self,
+        entries: Vec<api::PostSubmitRequestEntry>,
+        use_staked_rpcs: Option<bool>
+    ) -> anyhow::Result<api::PostSubmitSnipeResponse> {
+        let url = format!("{}/api/v2/submit-snipe", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "entries": entries,
+            "useStakedRPCs": use_staked_rpcs
+        });
+        
+        let response = self
+            .client
+            .post(&url)
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostSubmitSnipeResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+    
+    pub async fn post_submit_v2(
+        &self,
+        transaction: api::TransactionMessage,
+        skip_pre_flight: bool,
+        front_running_protection: Option<bool>,
+        tip: Option<u64>,
+        use_staked_rpcs: Option<bool>,
+        fast_best_effort: Option<bool>,
+        allow_back_run: Option<bool>,
+        revenue_address: Option<String>,
+        sniping: Option<bool>
+    ) -> anyhow::Result<api::PostSubmitResponse> {
+        let url = format!("{}/api/v2/submit", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "transaction": transaction,
+            "skipPreFlight": skip_pre_flight,
+            "frontRunningProtection": front_running_protection,
+            "tip": tip,
+            "useStakedRPCs": use_staked_rpcs,
+            "fastBestEffort": fast_best_effort,
+            "allowBackRun": allow_back_run,
+            "revenueAddress": revenue_address,
+            "sniping": sniping
+        });
+        
+        let response = self
+            .client
+            .post(&url)
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostSubmitResponse = self.handle_response(response).await?;
+        
+        Ok(result)
     }
 
     pub async fn sign_and_submit_paladin<T: IntoTransactionMessage + Clone>(
@@ -317,6 +464,7 @@ impl HTTPClient {
 
         self.handle_response(response).await
     }
+
     pub async fn get_recent_block_hash(&self) -> anyhow::Result<api::GetRecentBlockHashResponse> {
         let url = format!("{}/api/v1/system/blockhash", self.base_url);
 
@@ -330,6 +478,60 @@ impl HTTPClient {
             .map_err(|e| anyhow!("HTTP GET request failed: {}", e))?;
 
         self.handle_response(response).await
+    }
+
+    pub async fn get_server_time(&self) -> anyhow::Result<api::GetServerTimeResponse> {
+        let url = format!("{}/api/v1/system/time", self.base_url);
+
+        println!("{}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| anyhow!("HTTP GET request failed: {}", e))?;
+
+        self.handle_response(response).await
+    }
+
+    pub async fn post_submit(
+        &self, 
+        transaction: api::TransactionMessage,
+        skip_pre_flight: bool,
+        front_running_protection: Option<bool>,
+        tip: Option<u64>,
+        use_staked_rpcs: Option<bool>,
+        fast_best_effort: Option<bool>,
+        allow_back_run: Option<bool>,
+        revenue_address: Option<String>,
+        sniping: Option<bool>
+    ) -> anyhow::Result<api::PostSubmitResponse> {
+        let url = format!("{}/api/v1/trade/submit", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "transaction": transaction,
+            "skipPreFlight": skip_pre_flight,
+            "frontRunningProtection": front_running_protection,
+            "tip": tip,
+            "useStakedRPCs": use_staked_rpcs,
+            "fastBestEffort": fast_best_effort,
+            "allowBackRun": allow_back_run,
+            "revenueAddress": revenue_address,
+            "sniping": sniping
+        });
+        
+        let response = self
+            .client
+            .post(format!("{}/api/v1/trade/submit", self.base_url))
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostSubmitResponse = self.handle_response(response).await?;
+        
+        Ok(result)
     }
 
     pub async fn get_recent_block_hash_v2(

--- a/src/provider/http/quote.rs
+++ b/src/provider/http/quote.rs
@@ -43,6 +43,60 @@ impl HTTPClient {
         self.handle_response(response).await
     }
 
+    pub async fn get_raydium_clmm_pools(
+        &self,
+        pair_or_address: String
+    ) -> anyhow::Result<api::GetRaydiumClmmPoolsResponse> {
+        let url = format!("{}/api/v2/raydium/clmm-pools?pairOrAddress={}", self.base_url, pair_or_address);
+        println!("{}", url);
+        
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await?;
+            
+        let result: api::GetRaydiumClmmPoolsResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
+    pub async fn get_raydium_pools(
+        &self
+    ) -> anyhow::Result<api::GetRaydiumPoolsResponse> {
+        let url = format!("{}/api/v2/raydium/pools", self.base_url);
+        println!("{}", url);
+        
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await?;
+            
+        let result: api::GetRaydiumPoolsResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
+    pub async fn get_raydium_pool_reserve(
+        &self,
+        pairs_or_addresses: Vec<String>
+    ) -> anyhow::Result<api::GetRaydiumPoolReserveResponse> {
+        let pairs_query = pairs_or_addresses.join(",");
+        let url = format!("{}/api/v2/raydium/pool-reserves?pairsOrAddresses={}", self.base_url, pairs_query);
+        println!("{}", url);
+        
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await?;
+            
+        let result: api::GetRaydiumPoolReserveResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
     pub async fn get_raydium_clmm_quotes(
         &self,
         request: &api::GetRaydiumClmmQuotesRequest,

--- a/src/provider/http/swap.rs
+++ b/src/provider/http/swap.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use super::HTTPClient;
 use anyhow::Result;
+use serde_json::json;
 use base64::{engine::general_purpose, Engine};
 use solana_sdk::{
     message::{v0, VersionedMessage},
@@ -248,4 +249,83 @@ impl HTTPClient {
 
         self.handle_response(response).await
     }
+
+    pub async fn post_pump_fun_swap(
+        &self,
+        user_address: String,
+        bonding_curve_address: String,
+        token_address: String,
+        token_amount: f64,
+        sol_threshold: f64,
+        is_buy: bool,
+        slippage: f64,
+        compute_limit: u32,
+        compute_price: u64,
+        tip: Option<u64>
+    ) -> anyhow::Result<api::PostPumpFunSwapResponse> {
+        let url = format!("{}/api/v2/pumpfun/swap", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "userAddress": user_address,
+            "bondingCurveAddress": bonding_curve_address,
+            "tokenAddress": token_address,
+            "tokenAmount": token_amount,
+            "solThreshold": sol_threshold,
+            "isBuy": is_buy,
+            "slippage": slippage,
+            "computeLimit": compute_limit,
+            "computePrice": compute_price,
+            "tip": tip
+        });
+        
+        let response = self
+            .client
+            .post(&url)
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostPumpFunSwapResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
+    pub async fn post_pump_fun_swap_sol(
+        &self,
+        user_address: String,
+        bonding_curve_address: String,
+        token_address: String,
+        sol_amount: f64,
+        slippage: f64,
+        compute_limit: u32,
+        compute_price: u64,
+        tip: Option<u64>
+    ) -> anyhow::Result<api::PostPumpFunSwapResponse> {
+        let url = format!("{}/api/v2/pumpfun/swap-sol", self.base_url);
+        println!("{}", url);
+        
+        let request_json = json!({
+            "userAddress": user_address,
+            "bondingCurveAddress": bonding_curve_address,
+            "tokenAddress": token_address,
+            "solAmount": sol_amount,
+            "slippage": slippage,
+            "computeLimit": compute_limit,
+            "computePrice": compute_price,
+            "tip": tip
+        });
+        
+        let response = self
+            .client
+            .post(&url)
+            .json(&request_json)
+            .send()
+            .await?;
+            
+        let result: api::PostPumpFunSwapResponse = self.handle_response(response).await?;
+        
+        Ok(result)
+    }
+
 }

--- a/src/provider/ws/mod.rs
+++ b/src/provider/ws/mod.rs
@@ -310,4 +310,41 @@ impl WebSocketClient {
 
         self.conn.request("GetLeaderSchedule", params).await
     }
+
+    pub async fn get_server_time(
+        &self
+    ) -> Result<api::GetServerTimeResponse> {
+        self.conn.request("GetServerTime", json!({})).await
+    }
+
+    pub async fn post_submit(
+        &self,
+        request: &api::PostSubmitRequest
+    ) -> Result<api::PostSubmitResponse> {
+        let params = json!({
+            "transaction": request.transaction,
+            "skipPreFlight": request.skip_pre_flight,
+            "frontRunningProtection": request.front_running_protection,
+            "tip": request.tip,
+            "useStakedRPCs": request.use_staked_rp_cs,
+            "fastBestEffort": request.fast_best_effort,
+            "allowBackRun": request.allow_back_run,
+            "revenueAddress": request.revenue_address,
+            "sniping": request.sniping
+        });
+        self.conn.request("PostSubmit", params).await
+    }
+
+    pub async fn post_submit_batch(
+        &self,
+        request: &api::PostSubmitBatchRequest
+    ) -> Result<api::PostSubmitBatchResponse> {
+        let params = json!({
+            "entries": request.entries,
+            "submitStrategy": request.submit_strategy,
+            "useBundle": request.use_bundle,
+            "frontRunningProtection": request.front_running_protection
+        });
+        self.conn.request("PostSubmitBatch", params).await
+    }
 }

--- a/src/provider/ws/quote.rs
+++ b/src/provider/ws/quote.rs
@@ -34,6 +34,28 @@ impl WebSocketClient {
         self.conn.request("GetRaydiumCLMMQuotes", params).await
     }
 
+    pub async fn get_raydium_clmm_pools(
+        &self,
+        pair_or_address: String
+    ) -> Result<api::GetRaydiumClmmPoolsResponse> {
+        let request = api::GetRaydiumClmmPoolsRequest { pair_or_address };
+        self.conn.request("GetRaydiumCLMMPools", json!(request)).await
+    }
+    
+    pub async fn get_raydium_pool_reserve(
+        &self,
+        pairs_or_addresses: Vec<String>
+    ) -> Result<api::GetRaydiumPoolReserveRequest> {
+        let request = api::GetRaydiumPoolReserveRequest { pairs_or_addresses };
+        self.conn.request("GetRaydiumPoolReserve", json!(request)).await
+    }
+    
+    pub async fn get_raydium_pools(
+        &self
+    ) -> Result<api::GetRaydiumPoolsResponse> {
+        self.conn.request("GetRaydiumPools", json!({})).await
+    }
+
     pub async fn get_pump_fun_quotes(
         &self,
         request: &api::GetPumpFunQuotesRequest,

--- a/src/provider/ws/stream.rs
+++ b/src/provider/ws/stream.rs
@@ -212,4 +212,20 @@ impl WebSocketClient {
             .stream_proto("GetPumpFunSwapsStream", &request)
             .await
     }
+    
+
+    pub async fn get_quotes_stream(
+        &self,
+        projects: Vec<i32>,
+        token_pairs: Vec<api::TokenPair>
+    ) -> Result<impl Stream<Item = Result<api::GetPumpFunSwapsStreamResponse>>> {
+        let request = api::GetQuotesStreamRequest {
+            projects,
+            token_pairs,
+        };
+        
+        self.conn
+            .stream_proto("GetQuotesStream", &request)
+            .await
+    }
 }

--- a/src/provider/ws/swap.rs
+++ b/src/provider/ws/swap.rs
@@ -263,4 +263,40 @@ impl WebSocketClient {
 
         self.conn.request("PostRouteTradeSwap", params).await
     }
+
+    pub async fn post_pump_fun_swap(
+        &self,
+        request: &api::PostPumpFunSwapRequest
+    ) -> Result<api::PostPumpFunSwapResponse> {
+        let params = json!({
+            "userAddress": request.user_address,
+            "bondingCurveAddress": request.bonding_curve_address,
+            "tokenAddress": request.token_address,
+            "tokenAmount": request.token_amount,
+            "solThreshold": request.sol_threshold,
+            "isBuy": request.is_buy,
+            "slippage": request.slippage,
+            "computeLimit": request.compute_limit,
+            "computePrice": request.compute_price,
+            "tip": request.tip
+        });
+        self.conn.request("PostPumpFunSwap", params).await
+    }
+
+    pub async fn post_pump_fun_swap_sol(
+        &self,
+        request: &api::PostPumpFunSwapRequestSol
+    ) -> Result<api::PostPumpFunSwapResponse> {
+        let params = json!({
+            "userAddress": request.user_address,
+            "bondingCurveAddress": request.bonding_curve_address,
+            "tokenAddress": request.token_address,
+            "solAmount": request.sol_amount,
+            "slippage": request.slippage,
+            "computeLimit": request.compute_limit,
+            "computePrice": request.compute_price,
+            "tip": request.tip
+        });
+        self.conn.request("PostPumpFunSwapSol", params).await
+    }
 }


### PR DESCRIPTION
**Added support for the following missing endpoints:**

gRPC:

- GetServerTime
- PostSubmit
- PostSubmitBatch
- PostPumpFunSwapSol
- GetRaydiumCLMMPools
- GetRaydiumPoolReserve
- GetRaydiumPools
- GetQuotesStream

HTTP:

- GetServerTime
- PostSubmit
- PostSubmitBatch
- PostSubmitBatchV2
- PostSubmitPaladinV2
- PostSubmitSnipeV2
- PostSubmitV2
- PostPumpFunSwap
- PostPumpFunSwapSol
- GetRaydiumCLMMPools
- GetRaydiumPoolReserve
- GetRaydiumPools

WebSocket:

- GetServerTime
- PostSubmit
- PostSubmitBatch
- PostPumpFunSwap
- PostPumpFunSwapSol
- GetRaydiumCLMMPools
- GetRaydiumPoolReserve
- GetRaydiumPools
- GetQuotesStream

*examples and tests will be added as time permits*