### PR TITLE
Add Automatic Timestamp for Rust SDK Submit Calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitnet = "0.31.9"
 serde_json = "1.0.132"
 solana-sdk = "2.1.0"
 solana-hash = "2.1.0"
-solana-trader-proto = "0.2.1"
+solana-trader-proto = "0.2.2"
 thiserror = "1.0.65"
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-tungstenite = { version = "0.24.0", features = ["rustls-tls-webpki-roots"]}
@@ -54,9 +54,13 @@ env_logger = "0.11.5"
 async-trait = "0.1.83"
 tracing = "0.1.40"
 serial_test = "3.1.1"
+chrono = "0.4"
+prost-wkt-types = "0.6.0"
 
 [dev-dependencies]
 test-case = "3.3.1"
+solana-program = "1.18.0"
+bs58 = "0.5.0"
 
 [patch.crates-io.curve25519-dalek]
 git = "https://github.com/anza-xyz/curve25519-dalek.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-trader-client-rust"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["support@bloxroute.com"]
 description = "Solana Trader API client implementation"

--- a/src/provider/grpc/mod.rs
+++ b/src/provider/grpc/mod.rs
@@ -6,19 +6,20 @@ use anyhow::Result;
 use rustls::crypto::ring::default_provider;
 use rustls::crypto::CryptoProvider;
 use solana_sdk::pubkey::Pubkey;
-use solana_trader_proto::api::{self, GetServerTimeRequest, PostSubmitBatchRequest, TransactionMessageV2};
+use solana_trader_proto::api::{self, GetServerTimeRequest, PostSubmitBatchRequest, PostSubmitPaladinRequest, TransactionMessageV2};
 use std::collections::HashMap;
 use tonic::service::Interceptor;
 use tonic::transport::ClientTlsConfig;
 use tonic::{
     metadata::MetadataValue, service::interceptor::InterceptedService, transport::Channel, Request,
 };
+use crate::provider::utils::timestamp;
 
 use crate::common::signing::{sign_transaction, SubmitParams};
 use crate::common::{get_base_url_from_env, grpc_endpoint, is_submit_only_endpoint, BaseConfig};
 use solana_sdk::signature::Keypair;
 use solana_trader_proto::api::{
-    GetRecentBlockHashRequestV2, PostSubmitRequest, TransactionMessage,
+    GetRecentBlockHashRequestV2, PostSubmitRequest, TransactionMessage, PostSubmitSnipeRequest
 };
 
 use super::utils::IntoTransactionMessage;
@@ -133,6 +134,8 @@ impl GrpcClient {
                 allow_back_run: submit_opts.allow_back_run,
                 revenue_address: submit_opts.revenue_address,
                 sniping: Some(false),
+                timestamp: timestamp(),
+                submit_protection: None
             };
 
             let signature = self
@@ -164,6 +167,8 @@ impl GrpcClient {
             use_bundle: Some(use_bundle),
             submit_strategy: submit_opts.submit_strategy.into(),
             front_running_protection: Some(submit_opts.front_running_protection),
+            timestamp: timestamp(),
+            submit_protection: None
         };
 
         let response = self
@@ -213,6 +218,7 @@ impl GrpcClient {
         let snipe_request = api::PostSubmitSnipeRequest {
             entries,
             use_staked_rp_cs: Some(use_staked_rpcs),
+            timestamp: timestamp()
         };
 
         let response = self
@@ -251,6 +257,7 @@ impl GrpcClient {
                 content: signed_tx.content,
             }),
             revert_protection: Some(revert_protection),
+            timestamp: timestamp()
         };
 
         let signature = self
@@ -311,6 +318,45 @@ impl GrpcClient {
             .post_submit(Request::new(request.clone()))
             .await
             .map_err(|e| anyhow::anyhow!("PostSubmit error: {}", e))?;
+
+        return Ok(response.into_inner())
+    }
+
+    pub async fn post_submit_snipe_v2(
+        &mut self,
+        request: &PostSubmitSnipeRequest,
+    ) -> Result<api::PostSubmitSnipeResponse> {
+        let response: tonic::Response<api::PostSubmitSnipeResponse> = self
+            .client
+            .post_submit_snipe_v2(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("PostSubmitSnipeV2 error: {}", e))?;
+
+        return Ok(response.into_inner())
+    }
+
+    pub async fn post_submit_paladin_v2(
+        &mut self,
+        request: &PostSubmitPaladinRequest,
+    ) -> Result<api::PostSubmitResponse> {
+        let response: tonic::Response<api::PostSubmitResponse> = self
+            .client
+            .post_submit_paladin_v2(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("PostSubmitPaladinV2 error: {}", e))?;
+
+        return Ok(response.into_inner())
+    }
+
+    pub async fn post_submit_v2(
+        &mut self,
+        request: &PostSubmitRequest,
+    ) -> Result<api::PostSubmitResponse> {
+        let response: tonic::Response<api::PostSubmitResponse> = self
+            .client
+            .post_submit_v2(Request::new(request.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("PostSubmitV2 error: {}", e))?;
 
         return Ok(response.into_inner())
     }

--- a/src/provider/http/mod.rs
+++ b/src/provider/http/mod.rs
@@ -10,6 +10,7 @@ use serde::de::DeserializeOwned;
 use serde_json::json;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 use solana_trader_proto::api::{self, GetRecentBlockHashResponseV2};
+use crate::provider::utils::timestamp_rfc3339;
 
 use crate::{
     common::{
@@ -193,7 +194,8 @@ impl HTTPClient {
             "entries": entries,
             "submitStrategy": submit_strategy,
             "useBundle": use_bundle,
-            "frontRunningProtection": front_running_protection
+            "frontRunningProtection": front_running_protection,
+            "timestamp": timestamp_rfc3339()
         });
         
         let response = self
@@ -222,7 +224,8 @@ impl HTTPClient {
             "entries": entries,
             "submitStrategy": submit_strategy,
             "useBundle": use_bundle,
-            "frontRunningProtection": front_running_protection
+            "frontRunningProtection": front_running_protection,
+            "timestamp": timestamp_rfc3339()
         });
         
         let response = self
@@ -247,7 +250,8 @@ impl HTTPClient {
         
         let request_json = json!({
             "transaction": transaction,
-            "revertProtection": revert_protection
+            "revertProtection": revert_protection,
+            "timestamp": timestamp_rfc3339()
         });
         
         let response = self
@@ -329,7 +333,8 @@ impl HTTPClient {
         
         let request_json = json!({
             "entries": entries,
-            "useStakedRPCs": use_staked_rpcs
+            "useStakedRPCs": use_staked_rpcs,
+            "timestamp": timestamp_rfc3339()
         });
         
         let response = self
@@ -368,7 +373,8 @@ impl HTTPClient {
             "fastBestEffort": fast_best_effort,
             "allowBackRun": allow_back_run,
             "revenueAddress": revenue_address,
-            "sniping": sniping
+            "sniping": sniping,
+            "timestamp": timestamp_rfc3339()
         });
         
         let response = self
@@ -403,9 +409,9 @@ impl HTTPClient {
 
         let request_json = json!({
             "transaction": {
-                "content": signed_tx.content,
-            "revertProtection": revert_protection,
-            }
+                "content": signed_tx.content
+            },
+            "revertProtection": revert_protection
         });
 
         let response = self
@@ -519,7 +525,8 @@ impl HTTPClient {
             "fastBestEffort": fast_best_effort,
             "allowBackRun": allow_back_run,
             "revenueAddress": revenue_address,
-            "sniping": sniping
+            "sniping": sniping,
+            "timestamp": timestamp_rfc3339()
         });
         
         let response = self

--- a/src/provider/http/mod.rs
+++ b/src/provider/http/mod.rs
@@ -9,7 +9,7 @@ use reqwest::{
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
-use solana_trader_proto::api::{self, GetRecentBlockHashResponseV2};
+use solana_trader_proto::api::{self, PostSubmitPaladinRequest, GetRecentBlockHashResponseV2};
 use crate::provider::utils::timestamp_rfc3339;
 
 use crate::{
@@ -242,15 +242,14 @@ impl HTTPClient {
 
     pub async fn post_submit_paladin_v2(
         &self,
-        transaction: api::TransactionMessageV2,
-        revert_protection: Option<bool>
+        request: &PostSubmitPaladinRequest
     ) -> anyhow::Result<api::PostSubmitResponse> {
         let url = format!("{}/api/v2/submit-paladin", self.base_url);
         println!("{}", url);
         
         let request_json = json!({
-            "transaction": transaction,
-            "revertProtection": revert_protection,
+            "transaction": request.transaction,
+            "revertProtection": request.revert_protection,
             "timestamp": timestamp_rfc3339()
         });
         

--- a/src/provider/http/mod.rs
+++ b/src/provider/http/mod.rs
@@ -300,7 +300,8 @@ impl HTTPClient {
 
         let request_json = json!({
             "entries": entries,
-            "useStakedRPCs": use_staked_rpcs
+            "useStakedRPCs": use_staked_rpcs,
+            "timestamp": timestamp_rfc3339()
         });
 
         let response = self

--- a/src/provider/utils.rs
+++ b/src/provider/utils.rs
@@ -10,7 +10,9 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_trader_proto::api::{self, Project, TransactionMessage, TransactionMessageV2};
-
+use std::time::{SystemTime, UNIX_EPOCH};
+use chrono::{Utc, DateTime};
+use prost_wkt_types::Timestamp;
 pub trait IntoTransactionMessage {
     fn into_transaction_message(self) -> TransactionMessage;
 }
@@ -189,4 +191,25 @@ mod tests {
         assert_eq!(value["nested"]["priceImpactPercent"]["infinity"], 0);
         assert_eq!(value["array"][0]["project"], 5);
     }
+}
+
+/// Creates and returns a Protocol Buffer Timestamp object based on the current time.
+/// This function captures the current time and converts it to a Protocol Buffer
+pub fn timestamp() -> Option<Timestamp> {
+    SystemTime::now().duration_since(UNIX_EPOCH).ok().map(|duration| {
+        Timestamp {
+            seconds: duration.as_secs() as i64,
+            nanos: duration.subsec_nanos() as i32,
+        }
+    })
+}
+
+/// Returns the current time as an RFC 3339 formatted string suitable for
+/// Protocol Buffer Timestamp JSON serialization.
+pub fn timestamp_rfc3339() -> String {
+    let now: DateTime<Utc> = Utc::now();
+    format!("{}.{}Z", 
+        now.format("%Y-%m-%dT%H:%M:%S"),
+        format!("{:06}", now.timestamp_subsec_micros()).chars().take(3).collect::<String>() + "000"
+    )
 }

--- a/src/provider/ws/mod.rs
+++ b/src/provider/ws/mod.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use serde_json::json;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
-use solana_trader_proto::api::{self, GetRecentBlockHashResponseV2};
+use solana_trader_proto::api::{self, PostSubmitPaladinRequest, GetRecentBlockHashResponseV2};
 
 use crate::common::signing::{sign_transaction, SubmitParams};
 use crate::common::{get_base_url_from_env, is_submit_only_endpoint, ws_endpoint, BaseConfig};
@@ -337,6 +337,19 @@ impl WebSocketClient {
             "timestamp": timestamp_rfc3339()
         });
         self.conn.request("PostSubmit", params).await
+    }
+
+    pub async fn post_submit_paladin_v2(
+        &mut self,
+        request: &PostSubmitPaladinRequest,
+    ) -> Result<api::PostSubmitResponse> {
+
+        let params = json!({
+            "transaction": request.transaction,
+            "revertProtection": request.revert_protection,
+            "timestamp": timestamp_rfc3339()
+        });
+        self.conn.request("PostSubmitPaladinV2", params).await
     }
 
     pub async fn post_submit_v2(

--- a/src/provider/ws/mod.rs
+++ b/src/provider/ws/mod.rs
@@ -11,6 +11,7 @@ use solana_trader_proto::api::{self, GetRecentBlockHashResponseV2};
 use crate::common::signing::{sign_transaction, SubmitParams};
 use crate::common::{get_base_url_from_env, is_submit_only_endpoint, ws_endpoint, BaseConfig};
 use crate::connections::ws::WS;
+use crate::provider::utils::timestamp_rfc3339;
 
 use super::utils::IntoTransactionMessage;
 
@@ -153,7 +154,8 @@ impl WebSocketClient {
 
         let request = json!({
             "entries": entries,
-            "useStakedRPCs": use_staked_rpcs
+            "useStakedRPCs": use_staked_rpcs,
+            "timestamp": timestamp_rfc3339()
         });
 
         let response: serde_json::Value = self.conn.request("PostSubmitSnipeV2", request).await?;
@@ -184,7 +186,8 @@ impl WebSocketClient {
             "transaction": {
                 "content": signed_tx.content,
             },
-            "revertProtection": revert_protection
+            "revertProtection": revert_protection,
+            "timestamp": timestamp_rfc3339()
         });
 
         let response: serde_json::Value = self.conn.request("PostSubmitPaladinV2", request).await?;
@@ -330,9 +333,29 @@ impl WebSocketClient {
             "fastBestEffort": request.fast_best_effort,
             "allowBackRun": request.allow_back_run,
             "revenueAddress": request.revenue_address,
-            "sniping": request.sniping
+            "sniping": request.sniping,
+            "timestamp": timestamp_rfc3339()
         });
         self.conn.request("PostSubmit", params).await
+    }
+
+    pub async fn post_submit_v2(
+        &self,
+        request: &api::PostSubmitRequest
+    ) -> Result<api::PostSubmitResponse> {
+        let params = json!({
+            "transaction": request.transaction,
+            "skipPreFlight": request.skip_pre_flight,
+            "frontRunningProtection": request.front_running_protection,
+            "tip": request.tip,
+            "useStakedRPCs": request.use_staked_rp_cs,
+            "fastBestEffort": request.fast_best_effort,
+            "allowBackRun": request.allow_back_run,
+            "revenueAddress": request.revenue_address,
+            "sniping": request.sniping,
+            "timestamp": timestamp_rfc3339()
+        });
+        self.conn.request("PostSubmitV2", params).await
     }
 
     pub async fn post_submit_batch(
@@ -343,7 +366,8 @@ impl WebSocketClient {
             "entries": request.entries,
             "submitStrategy": request.submit_strategy,
             "useBundle": request.use_bundle,
-            "frontRunningProtection": request.front_running_protection
+            "frontRunningProtection": request.front_running_protection,
+            "timestamp": timestamp_rfc3339()
         });
         self.conn.request("PostSubmitBatch", params).await
     }

--- a/tests/grpc/mod.rs
+++ b/tests/grpc/mod.rs
@@ -1,15 +1,23 @@
 pub mod memo;
+// Local modules
 pub mod quote;
 pub mod stream;
 pub mod swap;
 
+// Standard library
 use std::str::FromStr;
 
+// External crates
 use anyhow::Result;
+use test_case::test_case;
 use base64::{engine::general_purpose, Engine};
 use solana_hash::Hash;
 use solana_sdk::{
-    pubkey::Pubkey, signature::Signature, signer::Signer as _, system_instruction,
+    compute_budget::ComputeBudgetInstruction,
+    pubkey::Pubkey,
+    signature::Signature,
+    signer::Signer as _,
+    system_instruction,
     transaction::Transaction,
 };
 use solana_trader_client_rust::{
@@ -17,12 +25,19 @@ use solana_trader_client_rust::{
         constants::{SAMPLE_OWNER_ADDR, SAMPLE_TX_SIGNATURE},
         signing::{create_signed_transaction, SubmitParams},
     },
-    provider::grpc::GrpcClient,
+    provider::{
+        grpc::GrpcClient,
+        utils::timestamp,
+    },
 };
-use solana_trader_proto::api::{self, PostSubmitPaladinRequest, PostSubmitRequest,GetRecentBlockHashRequestV2, TransactionMessage, TransactionMessageV2};
-use test_case::test_case;
-use solana_trader_client_rust::provider::utils::timestamp;
-use solana_sdk::compute_budget::ComputeBudgetInstruction;
+use solana_trader_proto::api::{
+    self,
+    GetRecentBlockHashRequestV2,
+    PostSubmitPaladinRequest,
+    PostSubmitRequest,
+    TransactionMessage,
+    TransactionMessageV2,
+};
 
 #[tokio::test]
 #[ignore]

--- a/tests/grpc/mod.rs
+++ b/tests/grpc/mod.rs
@@ -14,6 +14,7 @@ use base64::{engine::general_purpose, Engine};
 use solana_hash::Hash;
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction,
+    instruction::Instruction,
     pubkey::Pubkey,
     signature::Signature,
     signer::Signer as _,
@@ -39,6 +40,81 @@ use solana_trader_proto::api::{
     TransactionMessageV2,
 };
 
+// Constants for tests
+const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+const PALADIN_MIN_TIP: u64 = 10_000_001;
+const BLOXROUTE_TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+const PALADIN_MIN_PRIORITY_FEE_MICROLAMPORTS: u64 = 40_000_001;
+const PALADIN_MIN_COMPUTE_BUDGET_UNITS: u32 = 1_000_000;
+const SEND_AMOUNT_LAMPORTS: u64 = 1;
+
+// Helper function to create standard transfer instructions
+fn create_transfer_instructions(from: &Pubkey, tip_amount: u64) -> anyhow::Result<Vec<Instruction>> {
+    let tip_wallet = Pubkey::from_str(BLOXROUTE_TIP_WALLET)?;
+    
+    Ok(vec![
+        system_instruction::transfer(from, &tip_wallet, tip_amount),
+        system_instruction::transfer(from, from, SEND_AMOUNT_LAMPORTS),
+    ])
+}
+
+// Helper function to create paladin instructions with compute budget
+fn create_paladin_instructions(from: &Pubkey, tip_amount: u64) -> anyhow::Result<Vec<Instruction>> {
+    let tip_wallet = Pubkey::from_str(BLOXROUTE_TIP_WALLET)?;
+    
+    Ok(vec![
+        ComputeBudgetInstruction::set_compute_unit_limit(PALADIN_MIN_COMPUTE_BUDGET_UNITS),
+        ComputeBudgetInstruction::set_compute_unit_price(PALADIN_MIN_PRIORITY_FEE_MICROLAMPORTS),
+        system_instruction::transfer(from, &tip_wallet, tip_amount),
+        system_instruction::transfer(from, from, SEND_AMOUNT_LAMPORTS),
+    ])
+}
+
+// Helper function to prepare transaction message
+fn prepare_transaction_message(tx: Transaction) -> anyhow::Result<TransactionMessage> {
+    let serialized_tx = bincode::serialize(&tx)?;
+    
+    Ok(TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    })
+}
+
+// Helper function to prepare paladin transaction message
+fn prepare_paladin_transaction_message(tx: Transaction) -> anyhow::Result<TransactionMessageV2> {
+    let serialized_tx = bincode::serialize(&tx)?;
+    
+    Ok(TransactionMessageV2 {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+    })
+}
+
+// Helper function to create default submit request
+fn create_submit_request(transaction_message: TransactionMessage) -> PostSubmitRequest {
+    PostSubmitRequest {
+        transaction: Some(transaction_message),
+        skip_pre_flight: false,
+        front_running_protection: Some(false),
+        tip: Some(BLXROUTE_MIN_TIP),
+        allow_back_run: Some(true),
+        use_staked_rp_cs: Some(false),
+        fast_best_effort: Some(false),
+        revenue_address: None,
+        sniping: Some(false),
+        timestamp: timestamp(),
+        submit_protection: None,
+    }
+}
+
+// Helper function to create paladin submit request
+fn create_paladin_submit_request(transaction_message: TransactionMessageV2) -> PostSubmitPaladinRequest {
+    PostSubmitPaladinRequest {
+        transaction: Some(transaction_message),
+        revert_protection: Some(false),
+        timestamp: timestamp()
+    }
+}
+
 #[tokio::test]
 #[ignore]
 async fn test_post_submit() -> anyhow::Result<()> {
@@ -52,23 +128,12 @@ async fn test_post_submit() -> anyhow::Result<()> {
         .block_hash
         .parse::<Hash>()?;
     
-    // Define constants
-    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
-    const SEND_AMOUNT_LAMPORTS: u64 = 1;
-    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
-    
     // Get client's public key and keypair
     let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
     let keypair = client.get_keypair()?;
     
-    // Parse recipient address
-    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
-    
     // Create transaction instructions
-    let instructions = vec![
-        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
-        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
-    ];
+    let instructions = create_transfer_instructions(&pubkey, BLXROUTE_MIN_TIP)?;
     
     // Create and sign transaction
     let tx = create_signed_transaction(
@@ -78,27 +143,11 @@ async fn test_post_submit() -> anyhow::Result<()> {
         block_hash,
     )?;
     
-    // Serialize transaction
-    let serialized_tx = bincode::serialize(&tx)?;
-    let transaction_message = TransactionMessage {
-        content: general_purpose::STANDARD.encode(serialized_tx),
-        is_cleanup: false,
-    };
+    // Prepare transaction message
+    let transaction_message = prepare_transaction_message(tx)?;
     
-    // Create submit request with default options
-    let request = PostSubmitRequest {
-        transaction: Some(transaction_message),
-        skip_pre_flight: false,
-        front_running_protection: Some(false),
-        tip: Some(BLXROUTE_MIN_TIP),
-        allow_back_run: Some(true),
-        use_staked_rp_cs: Some(false),
-        fast_best_effort: Some(false),
-        revenue_address: None,
-        sniping: Some(false),
-        timestamp: timestamp(),
-        submit_protection: None,
-    };
+    // Create submit request
+    let request = create_submit_request(transaction_message);
     
     // Submit transaction and handle response
     let response = client.post_submit(&request).await?;
@@ -122,23 +171,12 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
         .block_hash
         .parse::<Hash>()?;
     
-    // Define constants
-    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
-    const SEND_AMOUNT_LAMPORTS: u64 = 1;
-    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
-    
     // Get client's public key and keypair
     let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
     let keypair = client.get_keypair()?;
     
-    // Parse recipient address
-    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
-    
     // Create transaction instructions
-    let instructions = vec![
-        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
-        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
-    ];
+    let instructions = create_transfer_instructions(&pubkey, BLXROUTE_MIN_TIP)?;
     
     // Create and sign transaction
     let tx = create_signed_transaction(
@@ -148,27 +186,11 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
         block_hash,
     )?;
     
-    // Serialize transaction
-    let serialized_tx = bincode::serialize(&tx)?;
-    let transaction_message = TransactionMessage {
-        content: general_purpose::STANDARD.encode(serialized_tx),
-        is_cleanup: false,
-    };
+    // Prepare transaction message
+    let transaction_message = prepare_transaction_message(tx)?;
     
-    // Create submit request with default options
-    let request = PostSubmitRequest {
-        transaction: Some(transaction_message),
-        skip_pre_flight: false,
-        front_running_protection: Some(false),
-        tip: Some(BLXROUTE_MIN_TIP),
-        allow_back_run: Some(true),
-        use_staked_rp_cs: Some(false),
-        fast_best_effort: Some(false),
-        revenue_address: None,
-        sniping: Some(false),
-        timestamp: timestamp(),
-        submit_protection: None,
-    };
+    // Create submit request
+    let request = create_submit_request(transaction_message);
     
     // Submit transaction and handle response
     let response = client.post_submit_v2(&request).await?;
@@ -195,27 +217,12 @@ async fn test_post_submit_paladin_v2() -> anyhow::Result<()> {
         .block_hash
         .parse::<Hash>()?;
     
-    // Define constants
-    const BLXROUTE_MIN_TIP: u64 = 10_000_000;
-    const SEND_AMOUNT_LAMPORTS: u64 = 1;
-    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
-    const PRIORITY_FEE_MICROLAMPORTS: u64 = 40_000_000;
-    const COMPUTE_BUDGET_UNITS: u32 = 1_000_000;
-    
     // Get client's public key and keypair
     let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
     let keypair = client.get_keypair()?;
     
-    // Parse recipient address
-    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
-    
-    // Create transaction instructions
-    let instructions = vec![
-        ComputeBudgetInstruction::set_compute_unit_limit(COMPUTE_BUDGET_UNITS),
-        ComputeBudgetInstruction::set_compute_unit_price(PRIORITY_FEE_MICROLAMPORTS),
-        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
-        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
-    ];
+    // Create transaction instructions with compute budget settings
+    let instructions = create_paladin_instructions(&pubkey, PALADIN_MIN_TIP)?;
     
     // Create and sign transaction
     let tx = create_signed_transaction(
@@ -225,18 +232,11 @@ async fn test_post_submit_paladin_v2() -> anyhow::Result<()> {
         block_hash,
     )?;
     
-    // Serialize transaction
-    let serialized_tx = bincode::serialize(&tx)?;
-    let transaction_message = TransactionMessageV2 {
-        content: general_purpose::STANDARD.encode(serialized_tx),
-    };
+    // Prepare paladin transaction message
+    let transaction_message = prepare_paladin_transaction_message(tx)?;
     
-    // Create submit request with default options
-    let request = PostSubmitPaladinRequest {
-        transaction: Some(transaction_message),
-        revert_protection: Some(false),
-        timestamp: timestamp()
-    };
+    // Create paladin submit request
+    let request = create_paladin_submit_request(transaction_message);
     
     // Submit transaction and handle response
     let response = client.post_submit_paladin_v2(&request).await?;

--- a/tests/grpc/mod.rs
+++ b/tests/grpc/mod.rs
@@ -19,8 +19,218 @@ use solana_trader_client_rust::{
     },
     provider::grpc::GrpcClient,
 };
-use solana_trader_proto::api::{self, GetRecentBlockHashRequestV2, TransactionMessage, TransactionMessageV2};
+use solana_trader_proto::api::{self, PostSubmitPaladinRequest, PostSubmitRequest,GetRecentBlockHashRequestV2, TransactionMessage, TransactionMessageV2};
 use test_case::test_case;
+use solana_trader_client_rust::provider::utils::timestamp;
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit() -> anyhow::Result<()> {
+    // Initialize client
+    let mut client = GrpcClient::new(None).await?;
+    
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash_v2(GetRecentBlockHashRequestV2 { offset: 0 })
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Define constants
+    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+    const SEND_AMOUNT_LAMPORTS: u64 = 1;
+    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Parse recipient address
+    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
+    
+    // Create transaction instructions
+    let instructions = vec![
+        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
+        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
+    ];
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Serialize transaction
+    let serialized_tx = bincode::serialize(&tx)?;
+    let transaction_message = TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    };
+    
+    // Create submit request with default options
+    let request = PostSubmitRequest {
+        transaction: Some(transaction_message),
+        skip_pre_flight: false,
+        front_running_protection: Some(false),
+        tip: Some(BLXROUTE_MIN_TIP),
+        allow_back_run: Some(true),
+        use_staked_rp_cs: Some(false),
+        fast_best_effort: Some(false),
+        revenue_address: None,
+        sniping: Some(false),
+        timestamp: timestamp(),
+        submit_protection: None,
+    };
+    
+    // Submit transaction and handle response
+    let response = client.post_submit(&request).await?;
+    
+    // Log response for debugging
+    println!("PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit_v2() -> anyhow::Result<()> {
+    // Initialize client
+    let mut client = GrpcClient::new(None).await?;
+    
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash_v2(GetRecentBlockHashRequestV2 { offset: 0 })
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Define constants
+    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+    const SEND_AMOUNT_LAMPORTS: u64 = 1;
+    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Parse recipient address
+    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
+    
+    // Create transaction instructions
+    let instructions = vec![
+        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
+        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
+    ];
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Serialize transaction
+    let serialized_tx = bincode::serialize(&tx)?;
+    let transaction_message = TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    };
+    
+    // Create submit request with default options
+    let request = PostSubmitRequest {
+        transaction: Some(transaction_message),
+        skip_pre_flight: false,
+        front_running_protection: Some(false),
+        tip: Some(BLXROUTE_MIN_TIP),
+        allow_back_run: Some(true),
+        use_staked_rp_cs: Some(false),
+        fast_best_effort: Some(false),
+        revenue_address: None,
+        sniping: Some(false),
+        timestamp: timestamp(),
+        submit_protection: None,
+    };
+    
+    // Submit transaction and handle response
+    let response = client.post_submit_v2(&request).await?;
+    
+    // Log response for debugging
+    println!("PostSubmitV2 Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
+
+// ************** READ *****************
+// Running this test will cost ~0.05 SOL
+// ************** READ *****************
+#[tokio::test]
+#[ignore]
+async fn test_post_submit_paladin_v2() -> anyhow::Result<()> {
+    // Initialize client
+    let mut client = GrpcClient::new(None).await?;
+    
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash_v2(GetRecentBlockHashRequestV2 { offset: 0 })
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Define constants
+    const BLXROUTE_MIN_TIP: u64 = 10_000_000;
+    const SEND_AMOUNT_LAMPORTS: u64 = 1;
+    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+    const PRIORITY_FEE_MICROLAMPORTS: u64 = 40_000_000;
+    const COMPUTE_BUDGET_UNITS: u32 = 1_000_000;
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Parse recipient address
+    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
+    
+    // Create transaction instructions
+    let instructions = vec![
+        ComputeBudgetInstruction::set_compute_unit_limit(COMPUTE_BUDGET_UNITS),
+        ComputeBudgetInstruction::set_compute_unit_price(PRIORITY_FEE_MICROLAMPORTS),
+        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
+        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
+    ];
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Serialize transaction
+    let serialized_tx = bincode::serialize(&tx)?;
+    let transaction_message = TransactionMessageV2 {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+    };
+    
+    // Create submit request with default options
+    let request = PostSubmitPaladinRequest {
+        transaction: Some(transaction_message),
+        revert_protection: Some(false),
+        timestamp: timestamp()
+    };
+    
+    // Submit transaction and handle response
+    let response = client.post_submit_paladin_v2(&request).await?;
+    
+    // Log response for debugging
+    println!("PostSubmitPaladinV2 Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
 
 #[test_case(SAMPLE_TX_SIGNATURE)]
 #[tokio::test]
@@ -33,10 +243,7 @@ async fn test_get_transaction_grpc(signature: &str) -> Result<()> {
     };
 
     let response = client.get_transaction(&request).await?;
-    println!(
-        "Get Transaction Response: {}",
-        serde_json::to_string_pretty(&response)?
-    );
+    println!("Get Transaction Response: {:?}", response);
     assert!(response.slot > 0, "Expected a lot in the tx response");
 
     Ok(())

--- a/tests/http/mod.rs
+++ b/tests/http/mod.rs
@@ -1,14 +1,18 @@
+// Local modules
 pub mod memo;
 pub mod quote;
 pub mod swap;
 
+// Standard library
 use std::str::FromStr;
 
+// External crates
 use anyhow::Result;
-
+use test_case::test_case;
 use base64::{engine::general_purpose, Engine};
 use solana_hash::Hash;
 use solana_sdk::{pubkey::Pubkey, system_instruction};
+use solana_trader_proto::api::{self, GetRecentBlockHashRequestV2, TransactionMessage};
 use solana_trader_client_rust::{
     common::{
         constants::{SAMPLE_OWNER_ADDR, SAMPLE_TX_SIGNATURE},
@@ -16,8 +20,134 @@ use solana_trader_client_rust::{
     },
     provider::http::HTTPClient,
 };
-use solana_trader_proto::api::{self, GetRecentBlockHashRequestV2, TransactionMessage};
-use test_case::test_case;
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit() -> anyhow::Result<()> {
+    // Initialize client
+    let client = HTTPClient::new(None)?;
+
+    let block_hash = client.
+        get_recent_block_hash().
+        await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Define constants
+    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+    const SEND_AMOUNT_LAMPORTS: u64 = 1;
+    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Parse recipient address
+    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
+    
+    // Create transaction instructions
+    let instructions = vec![
+        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
+        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
+    ];
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Serialize transaction
+    let serialized_tx = bincode::serialize(&tx)?;
+    let transaction_message = TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    };
+    
+    // Submit transaction and handle response
+    let response = client.post_submit(
+        transaction_message,                // transaction
+        false,                              // skip preflight
+        Some(false),                        // frp
+        Some(BLXROUTE_MIN_TIP),             // tip
+        Some(true),                         // allow back run
+        Some(false),                        // staked
+        Some(false),                        // fast best effort
+        None,                               // revenue address
+        Some(false),                        // sniping
+    ).await?;
+    
+    // Log response for debugging
+    println!("PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit_v2() -> anyhow::Result<()> {
+    // Initialize client
+    let client = HTTPClient::new(None)?;
+
+    let block_hash = client.
+        get_recent_block_hash().
+        await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Define constants
+    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+    const SEND_AMOUNT_LAMPORTS: u64 = 1;
+    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Parse recipient address
+    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
+    
+    // Create transaction instructions
+    let instructions = vec![
+        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
+        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
+    ];
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Serialize transaction
+    let serialized_tx = bincode::serialize(&tx)?;
+    let transaction_message = TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    };
+    
+    // Submit transaction and handle response
+    let response = client.post_submit_v2(
+        transaction_message,                // transaction
+        false,                              // skip preflight
+        Some(false),                        // frp
+        Some(BLXROUTE_MIN_TIP),             // tip
+        Some(true),                         // allow back run
+        Some(false),                        // staked
+        Some(false),                        // fast best effort
+        None,                               // revenue address
+        Some(false),                        // sniping
+    ).await?;
+    
+    // Log response for debugging
+    println!("PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
 
 #[test_case(SAMPLE_TX_SIGNATURE)]
 #[tokio::test]

--- a/tests/http/mod.rs
+++ b/tests/http/mod.rs
@@ -11,15 +11,78 @@ use anyhow::Result;
 use test_case::test_case;
 use base64::{engine::general_purpose, Engine};
 use solana_hash::Hash;
-use solana_sdk::{pubkey::Pubkey, system_instruction};
-use solana_trader_proto::api::{self, GetRecentBlockHashRequestV2, TransactionMessage};
+use solana_sdk::{
+    transaction::Transaction,
+    pubkey::Pubkey, system_instruction,
+    instruction::Instruction,
+    compute_budget::ComputeBudgetInstruction,
+};
+use solana_trader_proto::api::{self, PostSubmitPaladinRequest, GetRecentBlockHashRequestV2, TransactionMessage, TransactionMessageV2};
 use solana_trader_client_rust::{
     common::{
         constants::{SAMPLE_OWNER_ADDR, SAMPLE_TX_SIGNATURE},
         signing::create_signed_transaction,
     },
-    provider::http::HTTPClient,
+    provider::{http::HTTPClient, utils::timestamp},
 };
+
+// Constants for tests
+const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+const PALADIN_MIN_TIP: u64 = 10_000_001;
+const BLOXROUTE_TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+const PALADIN_MIN_PRIORITY_FEE_MICROLAMPORTS: u64 = 40_000_001;
+const PALADIN_MIN_COMPUTE_BUDGET_UNITS: u32 = 1_000_000;
+const SEND_AMOUNT_LAMPORTS: u64 = 1;
+
+// Helper function to create standard transfer instructions
+fn create_transfer_instructions(from: &Pubkey, tip_amount: u64) -> anyhow::Result<Vec<Instruction>> {
+    let tip_wallet = Pubkey::from_str(BLOXROUTE_TIP_WALLET)?;
+    
+    Ok(vec![
+        system_instruction::transfer(from, &tip_wallet, tip_amount),
+        system_instruction::transfer(from, from, SEND_AMOUNT_LAMPORTS),
+    ])
+}
+
+// Helper function to create paladin instructions with compute budget
+fn create_paladin_instructions(from: &Pubkey, tip_amount: u64) -> anyhow::Result<Vec<Instruction>> {
+    let tip_wallet = Pubkey::from_str(BLOXROUTE_TIP_WALLET)?;
+    
+    Ok(vec![
+        ComputeBudgetInstruction::set_compute_unit_limit(PALADIN_MIN_COMPUTE_BUDGET_UNITS),
+        ComputeBudgetInstruction::set_compute_unit_price(PALADIN_MIN_PRIORITY_FEE_MICROLAMPORTS),
+        system_instruction::transfer(from, &tip_wallet, tip_amount),
+        system_instruction::transfer(from, from, SEND_AMOUNT_LAMPORTS),
+    ])
+}
+
+// Helper function to prepare transaction message
+fn prepare_transaction_message(tx: Transaction) -> anyhow::Result<TransactionMessage> {
+    let serialized_tx = bincode::serialize(&tx)?;
+    
+    Ok(TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    })
+}
+
+// Helper function to prepare paladin transaction message
+fn prepare_paladin_transaction_message(tx: Transaction) -> anyhow::Result<TransactionMessageV2> {
+    let serialized_tx = bincode::serialize(&tx)?;
+    
+    Ok(TransactionMessageV2 {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+    })
+}
+
+// Helper function to create paladin submit request
+fn create_paladin_submit_request(transaction_message: TransactionMessageV2) -> PostSubmitPaladinRequest {
+    PostSubmitPaladinRequest {
+        transaction: Some(transaction_message),
+        revert_protection: Some(false),
+        timestamp: timestamp()
+    }
+}
 
 #[tokio::test]
 #[ignore]
@@ -27,29 +90,19 @@ async fn test_post_submit() -> anyhow::Result<()> {
     // Initialize client
     let client = HTTPClient::new(None)?;
 
-    let block_hash = client.
-        get_recent_block_hash().
-        await?
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash()
+        .await?
         .block_hash
         .parse::<Hash>()?;
-    
-    // Define constants
-    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
-    const SEND_AMOUNT_LAMPORTS: u64 = 1;
-    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
     
     // Get client's public key and keypair
     let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
     let keypair = client.get_keypair()?;
     
-    // Parse recipient address
-    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
-    
     // Create transaction instructions
-    let instructions = vec![
-        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
-        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
-    ];
+    let instructions = create_transfer_instructions(&pubkey, BLXROUTE_MIN_TIP)?;
     
     // Create and sign transaction
     let tx = create_signed_transaction(
@@ -59,12 +112,8 @@ async fn test_post_submit() -> anyhow::Result<()> {
         block_hash,
     )?;
     
-    // Serialize transaction
-    let serialized_tx = bincode::serialize(&tx)?;
-    let transaction_message = TransactionMessage {
-        content: general_purpose::STANDARD.encode(serialized_tx),
-        is_cleanup: false,
-    };
+    // Prepare transaction message
+    let transaction_message = prepare_transaction_message(tx)?;
     
     // Submit transaction and handle response
     let response = client.post_submit(
@@ -80,7 +129,7 @@ async fn test_post_submit() -> anyhow::Result<()> {
     ).await?;
     
     // Log response for debugging
-    println!("PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
+    println!("HTTP PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
     
     Ok(())
 }
@@ -91,29 +140,19 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
     // Initialize client
     let client = HTTPClient::new(None)?;
 
-    let block_hash = client.
-        get_recent_block_hash().
-        await?
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash()
+        .await?
         .block_hash
         .parse::<Hash>()?;
-    
-    // Define constants
-    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
-    const SEND_AMOUNT_LAMPORTS: u64 = 1;
-    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
     
     // Get client's public key and keypair
     let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
     let keypair = client.get_keypair()?;
     
-    // Parse recipient address
-    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
-    
     // Create transaction instructions
-    let instructions = vec![
-        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
-        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
-    ];
+    let instructions = create_transfer_instructions(&pubkey, BLXROUTE_MIN_TIP)?;
     
     // Create and sign transaction
     let tx = create_signed_transaction(
@@ -123,12 +162,8 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
         block_hash,
     )?;
     
-    // Serialize transaction
-    let serialized_tx = bincode::serialize(&tx)?;
-    let transaction_message = TransactionMessage {
-        content: general_purpose::STANDARD.encode(serialized_tx),
-        is_cleanup: false,
-    };
+    // Prepare transaction message
+    let transaction_message = prepare_transaction_message(tx)?;
     
     // Submit transaction and handle response
     let response = client.post_submit_v2(
@@ -144,7 +179,53 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
     ).await?;
     
     // Log response for debugging
-    println!("PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
+    println!("HTTP PostSubmitV2 Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
+
+// ************** READ *****************
+// Running this test will cost ~0.05 SOL
+// ************** READ *****************
+#[tokio::test]
+#[ignore]
+async fn test_post_submit_paladin_v2() -> anyhow::Result<()> {
+    // Initialize client
+    let client = HTTPClient::new(None)?;
+
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash()
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Create transaction instructions with compute budget settings
+    let instructions = create_paladin_instructions(&pubkey, PALADIN_MIN_TIP)?;
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Prepare paladin transaction message
+    let transaction_message = prepare_paladin_transaction_message(tx)?;
+    
+    // Create paladin submit request
+    let request = create_paladin_submit_request(transaction_message);
+    
+    // Submit transaction and handle response
+    let response = client.post_submit_paladin_v2(&request).await?;
+    
+    // Log response for debugging
+    println!("HTTP PostSubmitPaladinV2 Response: {}", serde_json::to_string_pretty(&response)?);
     
     Ok(())
 }

--- a/tests/ws/mod.rs
+++ b/tests/ws/mod.rs
@@ -16,6 +16,8 @@ use solana_sdk::{
     pubkey::Pubkey,
     system_instruction,
     transaction::Transaction,
+    instruction::Instruction,
+    compute_budget::ComputeBudgetInstruction,
 };
 use tokio::time::timeout;
 
@@ -36,58 +38,60 @@ use solana_trader_proto::api::{
     PostSubmitRequest,
     TransactionMessage,
     TransactionMessageV2,
+    PostSubmitPaladinRequest
 };
+// Constants for tests
+const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+const PALADIN_MIN_TIP: u64 = 10_000_001;
+const BLOXROUTE_TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+const PALADIN_MIN_PRIORITY_FEE_MICROLAMPORTS: u64 = 40_000_001;
+const PALADIN_MIN_COMPUTE_BUDGET_UNITS: u32 = 1_000_000;
+const SEND_AMOUNT_LAMPORTS: u64 = 1;
 
-#[tokio::test]
-#[ignore]
-async fn test_post_submit() -> anyhow::Result<()> {
-    // Initialize client
-    let client = WebSocketClient::new(None).await?;
+// Helper function to create standard transfer instructions
+fn create_transfer_instructions(from: &Pubkey, tip_amount: u64) -> anyhow::Result<Vec<Instruction>> {
+    let tip_wallet = Pubkey::from_str(BLOXROUTE_TIP_WALLET)?;
+    
+    Ok(vec![
+        system_instruction::transfer(from, &tip_wallet, tip_amount),
+        system_instruction::transfer(from, from, SEND_AMOUNT_LAMPORTS),
+    ])
+}
 
-    let blockhash_request = GetRecentBlockHashRequestV2 { offset: 0 };
+// Helper function to create paladin instructions with compute budget
+fn create_paladin_instructions(from: &Pubkey, tip_amount: u64) -> anyhow::Result<Vec<Instruction>> {
+    let tip_wallet = Pubkey::from_str(BLOXROUTE_TIP_WALLET)?;
     
-    // Get recent block hash
-    let block_hash = client
-        .get_recent_block_hash_v2(&blockhash_request)
-        .await?
-        .block_hash
-        .parse::<Hash>()?;
-    
-    // Define constants
-    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
-    const SEND_AMOUNT_LAMPORTS: u64 = 1;
-    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
-    
-    // Get client's public key and keypair
-    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
-    let keypair = client.get_keypair()?;
-    
-    // Parse recipient address
-    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
-    
-    // Create transaction instructions
-    let instructions = vec![
-        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
-        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
-    ];
-    
-    // Create and sign transaction
-    let tx = create_signed_transaction(
-        instructions,
-        &pubkey,
-        keypair,
-        block_hash,
-    )?;
-    
-    // Serialize transaction
+    Ok(vec![
+        ComputeBudgetInstruction::set_compute_unit_limit(PALADIN_MIN_COMPUTE_BUDGET_UNITS),
+        ComputeBudgetInstruction::set_compute_unit_price(PALADIN_MIN_PRIORITY_FEE_MICROLAMPORTS),
+        system_instruction::transfer(from, &tip_wallet, tip_amount),
+        system_instruction::transfer(from, from, SEND_AMOUNT_LAMPORTS),
+    ])
+}
+
+// Helper function to prepare transaction message
+fn prepare_transaction_message(tx: Transaction) -> anyhow::Result<TransactionMessage> {
     let serialized_tx = bincode::serialize(&tx)?;
-    let transaction_message = TransactionMessage {
+    
+    Ok(TransactionMessage {
         content: general_purpose::STANDARD.encode(serialized_tx),
         is_cleanup: false,
-    };
+    })
+}
+
+// Helper function to prepare paladin transaction message
+fn prepare_paladin_transaction_message(tx: Transaction) -> anyhow::Result<TransactionMessageV2> {
+    let serialized_tx = bincode::serialize(&tx)?;
     
-    // Create submit request with default options
-    let request = PostSubmitRequest {
+    Ok(TransactionMessageV2 {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+    })
+}
+
+// Helper function to create default submit request
+fn create_submit_request(transaction_message: TransactionMessage) -> PostSubmitRequest {
+    PostSubmitRequest {
         transaction: Some(transaction_message),
         skip_pre_flight: false,
         front_running_protection: Some(false),
@@ -99,17 +103,63 @@ async fn test_post_submit() -> anyhow::Result<()> {
         sniping: Some(false),
         timestamp: timestamp(),
         submit_protection: None,
-    };
+    }
+}
+
+// Helper function to create paladin submit request
+fn create_paladin_submit_request(transaction_message: TransactionMessageV2) -> PostSubmitPaladinRequest {
+    PostSubmitPaladinRequest {
+        transaction: Some(transaction_message),
+        revert_protection: Some(false),
+        timestamp: timestamp()
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit() -> anyhow::Result<()> {
+    // Initialize client
+    let client = WebSocketClient::new(None).await?;
+    
+    // Create blockhash request
+    let blockhash_request = GetRecentBlockHashRequestV2 { offset: 0 };
+    
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash_v2(&blockhash_request)
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Create transaction instructions
+    let instructions = create_transfer_instructions(&pubkey, BLXROUTE_MIN_TIP)?;
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Prepare transaction message
+    let transaction_message = prepare_transaction_message(tx)?;
+    
+    // Create submit request
+    let request = create_submit_request(transaction_message);
     
     // Submit transaction and handle response
     let response = client.post_submit(&request).await?;
     
     // Log response for debugging
-    println!("PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
+    println!("WebSocket PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
     
     Ok(())
 }
-
 
 #[tokio::test]
 #[ignore]
@@ -117,8 +167,9 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
     // Initialize client
     let client = WebSocketClient::new(None).await?;
     
+    // Create blockhash request
     let blockhash_request = GetRecentBlockHashRequestV2 { offset: 0 };
-
+    
     // Get recent block hash
     let block_hash = client
         .get_recent_block_hash_v2(&blockhash_request)
@@ -126,23 +177,12 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
         .block_hash
         .parse::<Hash>()?;
     
-    // Define constants
-    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
-    const SEND_AMOUNT_LAMPORTS: u64 = 1;
-    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
-    
     // Get client's public key and keypair
     let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
     let keypair = client.get_keypair()?;
     
-    // Parse recipient address
-    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
-    
     // Create transaction instructions
-    let instructions = vec![
-        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
-        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
-    ];
+    let instructions = create_transfer_instructions(&pubkey, BLXROUTE_MIN_TIP)?;
     
     // Create and sign transaction
     let tx = create_signed_transaction(
@@ -152,33 +192,63 @@ async fn test_post_submit_v2() -> anyhow::Result<()> {
         block_hash,
     )?;
     
-    // Serialize transaction
-    let serialized_tx = bincode::serialize(&tx)?;
-    let transaction_message = TransactionMessage {
-        content: general_purpose::STANDARD.encode(serialized_tx),
-        is_cleanup: false,
-    };
+    // Prepare transaction message
+    let transaction_message = prepare_transaction_message(tx)?;
     
-    // Create submit request with default options
-    let request = PostSubmitRequest {
-        transaction: Some(transaction_message),
-        skip_pre_flight: false,
-        front_running_protection: Some(false),
-        tip: Some(BLXROUTE_MIN_TIP),
-        allow_back_run: Some(true),
-        use_staked_rp_cs: Some(false),
-        fast_best_effort: Some(false),
-        revenue_address: None,
-        sniping: Some(false),
-        timestamp: timestamp(),
-        submit_protection: None,
-    };
+    // Create submit request
+    let request = create_submit_request(transaction_message);
     
     // Submit transaction and handle response
     let response = client.post_submit_v2(&request).await?;
     
     // Log response for debugging
-    println!("PostSubmitV2 Response: {}", serde_json::to_string_pretty(&response)?);
+    println!("WebSocket PostSubmitV2 Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit_paladin_v2() -> anyhow::Result<()> {
+    // Initialize client
+    let mut client = WebSocketClient::new(None).await?;
+    
+    // Create blockhash request
+    let blockhash_request = GetRecentBlockHashRequestV2 { offset: 0 };
+    
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash_v2(&blockhash_request)
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Create transaction instructions with compute budget settings
+    let instructions = create_paladin_instructions(&pubkey, PALADIN_MIN_TIP)?;
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Prepare paladin transaction message
+    let transaction_message = prepare_paladin_transaction_message(tx)?;
+    
+    // Create paladin submit request
+    let request = create_paladin_submit_request(transaction_message);
+    
+    // Submit transaction and handle response
+    let response = client.post_submit_paladin_v2(&request).await?;
+    
+    // Log response for debugging
+    println!("WebSocket PostSubmitPaladinV2 Response: {}", serde_json::to_string_pretty(&response)?);
     
     Ok(())
 }

--- a/tests/ws/mod.rs
+++ b/tests/ws/mod.rs
@@ -1,25 +1,42 @@
+// Local modules
 pub mod memo;
 pub mod quote;
 pub mod stream;
 pub mod swap;
 
+// Standard library
+use std::{str::FromStr, time::Duration};
+
+// External crates
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine};
-use solana_sdk::{pubkey::Pubkey, system_instruction, transaction::Transaction};
-use std::{str::FromStr, time::Duration};
+use test_case::test_case;
+use solana_hash::Hash;
+use solana_sdk::{
+    pubkey::Pubkey,
+    system_instruction,
+    transaction::Transaction,
+};
 use tokio::time::timeout;
 
-use solana_hash::Hash;
+// Project crates
 use solana_trader_client_rust::{
     common::{
         constants::{SAMPLE_OWNER_ADDR, SAMPLE_TX_SIGNATURE},
         signing::create_signed_transaction,
     },
-    provider::ws::WebSocketClient,
-    provider::utils::timestamp,
+    provider::{
+        utils::timestamp,
+        ws::WebSocketClient,
+    },
 };
-use solana_trader_proto::api::{self, PostSubmitRequest, GetRecentBlockHashRequestV2, TransactionMessage, TransactionMessageV2};
-use test_case::test_case;
+use solana_trader_proto::api::{
+    self,
+    GetRecentBlockHashRequestV2,
+    PostSubmitRequest,
+    TransactionMessage,
+    TransactionMessageV2,
+};
 
 #[tokio::test]
 #[ignore]

--- a/tests/ws/mod.rs
+++ b/tests/ws/mod.rs
@@ -16,9 +16,156 @@ use solana_trader_client_rust::{
         signing::create_signed_transaction,
     },
     provider::ws::WebSocketClient,
+    provider::utils::timestamp,
 };
-use solana_trader_proto::api::{self, GetRecentBlockHashRequestV2, TransactionMessage, TransactionMessageV2};
+use solana_trader_proto::api::{self, PostSubmitRequest, GetRecentBlockHashRequestV2, TransactionMessage, TransactionMessageV2};
 use test_case::test_case;
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit() -> anyhow::Result<()> {
+    // Initialize client
+    let client = WebSocketClient::new(None).await?;
+
+    let blockhash_request = GetRecentBlockHashRequestV2 { offset: 0 };
+    
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash_v2(&blockhash_request)
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Define constants
+    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+    const SEND_AMOUNT_LAMPORTS: u64 = 1;
+    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Parse recipient address
+    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
+    
+    // Create transaction instructions
+    let instructions = vec![
+        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
+        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
+    ];
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Serialize transaction
+    let serialized_tx = bincode::serialize(&tx)?;
+    let transaction_message = TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    };
+    
+    // Create submit request with default options
+    let request = PostSubmitRequest {
+        transaction: Some(transaction_message),
+        skip_pre_flight: false,
+        front_running_protection: Some(false),
+        tip: Some(BLXROUTE_MIN_TIP),
+        allow_back_run: Some(true),
+        use_staked_rp_cs: Some(false),
+        fast_best_effort: Some(false),
+        revenue_address: None,
+        sniping: Some(false),
+        timestamp: timestamp(),
+        submit_protection: None,
+    };
+    
+    // Submit transaction and handle response
+    let response = client.post_submit(&request).await?;
+    
+    // Log response for debugging
+    println!("PostSubmit Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
+
+
+#[tokio::test]
+#[ignore]
+async fn test_post_submit_v2() -> anyhow::Result<()> {
+    // Initialize client
+    let client = WebSocketClient::new(None).await?;
+    
+    let blockhash_request = GetRecentBlockHashRequestV2 { offset: 0 };
+
+    // Get recent block hash
+    let block_hash = client
+        .get_recent_block_hash_v2(&blockhash_request)
+        .await?
+        .block_hash
+        .parse::<Hash>()?;
+    
+    // Define constants
+    const BLXROUTE_MIN_TIP: u64 = 1_000_000;
+    const SEND_AMOUNT_LAMPORTS: u64 = 1;
+    const TIP_WALLET: &str = "HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY";
+    
+    // Get client's public key and keypair
+    let pubkey = client.public_key.ok_or_else(|| anyhow::anyhow!("Missing public key"))?;
+    let keypair = client.get_keypair()?;
+    
+    // Parse recipient address
+    let tip_wallet = Pubkey::from_str(TIP_WALLET)?;
+    
+    // Create transaction instructions
+    let instructions = vec![
+        system_instruction::transfer(&pubkey, &tip_wallet, BLXROUTE_MIN_TIP),
+        system_instruction::transfer(&pubkey, &pubkey, SEND_AMOUNT_LAMPORTS),
+    ];
+    
+    // Create and sign transaction
+    let tx = create_signed_transaction(
+        instructions,
+        &pubkey,
+        keypair,
+        block_hash,
+    )?;
+    
+    // Serialize transaction
+    let serialized_tx = bincode::serialize(&tx)?;
+    let transaction_message = TransactionMessage {
+        content: general_purpose::STANDARD.encode(serialized_tx),
+        is_cleanup: false,
+    };
+    
+    // Create submit request with default options
+    let request = PostSubmitRequest {
+        transaction: Some(transaction_message),
+        skip_pre_flight: false,
+        front_running_protection: Some(false),
+        tip: Some(BLXROUTE_MIN_TIP),
+        allow_back_run: Some(true),
+        use_staked_rp_cs: Some(false),
+        fast_best_effort: Some(false),
+        revenue_address: None,
+        sniping: Some(false),
+        timestamp: timestamp(),
+        submit_protection: None,
+    };
+    
+    // Submit transaction and handle response
+    let response = client.post_submit_v2(&request).await?;
+    
+    // Log response for debugging
+    println!("PostSubmitV2 Response: {}", serde_json::to_string_pretty(&response)?);
+    
+    Ok(())
+}
+
 #[test_case(SAMPLE_TX_SIGNATURE)]
 #[tokio::test]
 #[ignore]


### PR DESCRIPTION
## Added Automatic Timestamping to Rust SDK Submit Calls

### Version Bumps
1. Updated `solana-trader-proto` to `v0.2.2` to include Atul’s `timestamp` field in the protobuf message definitions.
2. Bumped `solana-trader-client-rust` to `v0.1.5` for the next release.

### Integration Tests
3. Added integration tests for the following methods to verify timestamp propagation via Elasticsearch logs:
   - `test_post_submit`
   - `test_post_submit_v2`
   - `test_post_submit_paladin_v2`

### Timestamping Support
4. Implemented automatic timestamping for the following submit calls across **GRPC**, **HTTP**, and **WebSocket** providers:
   - `PostSubmit`
   - `PostSubmitBatch`
   - `PostSubmitSnipe`
   - `PostSubmitPaladin`

### Missing Method Implementations
5. Added the following previously unimplemented submit methods:

**GRPC:**
- `post_submit_snipe_v2`
- `post_submit_paladin_v2`
- `post_submit_v2`

**WebSocket:**
- `post_submit_paladin_v2`
- `post_submit_v2`