### PR TITLE
bump solana-program dev dependancy version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ prost-wkt-types = "0.6.0"
 
 [dev-dependencies]
 test-case = "3.3.1"
-solana-program = "1.18.0"
+solana-program = "2.2.1"
 bs58 = "0.5.0"
 
 [patch.crates-io.curve25519-dalek]


### PR DESCRIPTION
the `solana-program` dev dependancy used for our testing suite had a version conflict with `zeroize`.

curve25519-dalek v3.2.1 (used by solana-program v1.18.26) requires zeroize with version >=1, <1.4
rustls v0.23.25 requires zeroize v1.8.1

These requirements are incompatible with each other, as the version needed by rustls is outside the range accepted by curve25519-dalek.

We bump `solana-program` to `2.2.1` for compatibility. This package is only used for testing.