### PR TITLE
bump cargo version for ci

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-trader-client-rust"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["support@bloxroute.com"]
 description = "Solana Trader API client implementation"


### PR DESCRIPTION
**CI**
- Bumped TypeScript SDK version for NPM deployment