### PR TITLE
sign without reserializing and introducing larger transaction size

### DIFF
--- a/src/common/signing.rs
+++ b/src/common/signing.rs
@@ -81,18 +81,25 @@ pub fn create_signed_transaction(
 
 fn sign_existing_transaction(base64_tx: &str, keypair: &Keypair) -> Result<String> {
     let tx_bytes = STANDARD.decode(base64_tx)?;
-    let mut tx: VersionedTransaction = bincode::deserialize(&tx_bytes)?;
 
-    // Find the index of the zero signature
-    let sig_index = tx.signatures.iter().position(|sig| sig == &Signature::default())
-        .ok_or_else(|| anyhow!("No empty signature slot found"))?;
+    // Versioned transactions should be a super set of versioned and legacy transactions
+    if let Ok(mut tx) = bincode::deserialize::<VersionedTransaction>(&tx_bytes) {
+        // sign versioned tx logic here
+        let sig_index = tx.signatures.iter().position(|sig| *sig == Signature::default())
+            .ok_or_else(|| anyhow!("No empty signature slot found"))?;
 
-    // Sign the message
-    let msg_bytes = bincode::serialize(&tx.message)?;
-    let signature = keypair.sign_message(&msg_bytes);
-    tx.signatures[sig_index] = signature;
+        let msg_bytes = tx.message.serialize();
+        tx.signatures[sig_index] = keypair.sign_message(&msg_bytes);
 
-    let signed_bytes = bincode::serialize(&tx)?;
+        let signed_bytes = bincode::serialize(&tx)?;
+        return Ok(STANDARD.encode(signed_bytes));
+    }
+
+    // Fallback to legacy
+    let mut legacy_tx: Transaction = bincode::deserialize(&tx_bytes)?;
+    legacy_tx.try_partial_sign(&[keypair], legacy_tx.message.recent_blockhash)?;
+    let signed_bytes = bincode::serialize(&legacy_tx)?;
     Ok(STANDARD.encode(signed_bytes))
 }
+
 

--- a/src/common/signing.rs
+++ b/src/common/signing.rs
@@ -50,7 +50,6 @@ pub struct SignedTransaction {
 pub async fn sign_transaction<T>(
     tx: &T,
     keypair: &Keypair,
-    _blockhash: String, // no longer needed in this path
 ) -> Result<SignedTransaction>
 where
     T: IntoTransactionMessage + Clone,

--- a/src/common/signing.rs
+++ b/src/common/signing.rs
@@ -84,7 +84,6 @@ fn sign_existing_transaction(base64_tx: &str, keypair: &Keypair) -> Result<Strin
 
     // Versioned transactions should be a super set of versioned and legacy transactions
     if let Ok(mut tx) = bincode::deserialize::<VersionedTransaction>(&tx_bytes) {
-        // sign versioned tx logic here
         let sig_index = tx.signatures.iter().position(|sig| *sig == Signature::default())
             .ok_or_else(|| anyhow!("No empty signature slot found"))?;
 

--- a/src/common/signing.rs
+++ b/src/common/signing.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
 use base64::{engine::general_purpose::STANDARD, Engine};
-use bincode::{deserialize, serialize};
 use serde::Serialize;
+use anyhow::{anyhow};
 use solana_hash::Hash;
 use solana_sdk::{
     instruction::Instruction,
-    message::VersionedMessage,
     pubkey::Pubkey,
     signature::{Keypair, Signature},
     signer::Signer,
@@ -51,55 +50,18 @@ pub struct SignedTransaction {
 pub async fn sign_transaction<T>(
     tx: &T,
     keypair: &Keypair,
-    blockhash: String,
+    _blockhash: String, // no longer needed in this path
 ) -> Result<SignedTransaction>
 where
     T: IntoTransactionMessage + Clone,
 {
     let tx_message = tx.clone().into_transaction_message();
-    let rawbytes = STANDARD.decode(&tx_message.content)?;
-    let parsed_hash = blockhash.parse()?;
 
-    let signed_data = match deserialize(&rawbytes) {
-        Ok(versioned_tx) => sign_versioned_transaction(versioned_tx, keypair, parsed_hash)?,
-        Err(_) => sign_legacy_transaction(&rawbytes, keypair, parsed_hash)?,
-    };
-
+    let signed_b64 = sign_existing_transaction(&tx_message.content, keypair)?;
     Ok(SignedTransaction {
-        content: STANDARD.encode(signed_data),
+        content: signed_b64,
         is_cleanup: tx_message.is_cleanup,
     })
-}
-
-fn sign_versioned_transaction(
-    mut tx: VersionedTransaction,
-    keypair: &Keypair,
-    blockhash: solana_sdk::hash::Hash,
-) -> Result<Vec<u8>> {
-    match &mut tx.message {
-        VersionedMessage::Legacy(message) => {
-            message.recent_blockhash = blockhash;
-        }
-        VersionedMessage::V0(message) => {
-            message.recent_blockhash = blockhash;
-        }
-    }
-
-    tx.signatures = vec![Signature::default()];
-    let message_data = tx.message.serialize();
-    tx.signatures[0] = keypair.sign_message(&message_data);
-
-    Ok(serialize(&tx)?)
-}
-
-fn sign_legacy_transaction(
-    rawbytes: &[u8],
-    keypair: &Keypair,
-    blockhash: solana_sdk::hash::Hash,
-) -> Result<Vec<u8>> {
-    let mut tx: Transaction = deserialize(rawbytes)?;
-    tx.try_partial_sign(&[keypair], blockhash)?;
-    Ok(serialize(&tx)?)
 }
 
 pub fn create_signed_transaction(
@@ -117,3 +79,21 @@ pub fn create_signed_transaction(
 
     Ok(transaction)
 }
+
+fn sign_existing_transaction(base64_tx: &str, keypair: &Keypair) -> Result<String> {
+    let tx_bytes = STANDARD.decode(base64_tx)?;
+    let mut tx: VersionedTransaction = bincode::deserialize(&tx_bytes)?;
+
+    // Find the index of the zero signature
+    let sig_index = tx.signatures.iter().position(|sig| sig == &Signature::default())
+        .ok_or_else(|| anyhow!("No empty signature slot found"))?;
+
+    // Sign the message
+    let msg_bytes = bincode::serialize(&tx.message)?;
+    let signature = keypair.sign_message(&msg_bytes);
+    tx.signatures[sig_index] = signature;
+
+    let signed_bytes = bincode::serialize(&tx)?;
+    Ok(STANDARD.encode(signed_bytes))
+}
+

--- a/src/provider/grpc/mod.rs
+++ b/src/provider/grpc/mod.rs
@@ -116,17 +116,10 @@ impl GrpcClient {
         submit_opts: SubmitParams,
         use_bundle: bool,
     ) -> Result<Vec<String>> {
-        let block_hash = self
-            .client
-            .get_recent_block_hash_v2(GetRecentBlockHashRequestV2 { offset: 0 })
-            .await?
-            .into_inner()
-            .block_hash;
-
         let keypair = self.get_keypair()?;
 
         if txs.len() == 1 {
-            let signed_tx = sign_transaction(&txs[0], keypair, block_hash).await?;
+            let signed_tx = sign_transaction(&txs[0], keypair).await?;
 
             let req = PostSubmitRequest {
                 transaction: Some(TransactionMessage {
@@ -157,7 +150,7 @@ impl GrpcClient {
 
         let mut entries = Vec::with_capacity(txs.len());
         for tx in txs {
-            let signed_tx = sign_transaction(&tx, keypair, block_hash.clone()).await?;
+            let signed_tx = sign_transaction(&tx, keypair).await?;
 
             let entry = api::PostSubmitRequestEntry {
                 transaction: Some(TransactionMessage {
@@ -199,18 +192,11 @@ impl GrpcClient {
         txs: Vec<T>,
         use_staked_rpcs: bool,
     ) -> Result<Vec<String>> {
-        let block_hash = self
-            .client
-            .get_recent_block_hash_v2(GetRecentBlockHashRequestV2 { offset: 0 })
-            .await?
-            .into_inner()
-            .block_hash;
-
         let keypair = self.get_keypair()?;
 
         let mut entries = Vec::with_capacity(txs.len());
         for tx in txs {
-            let signed_tx = sign_transaction(&tx, keypair, block_hash.clone()).await?;
+            let signed_tx = sign_transaction(&tx, keypair).await?;
 
             let entry = api::PostSubmitRequestEntry {
                 transaction: Some(TransactionMessage {
@@ -249,15 +235,8 @@ impl GrpcClient {
         tx: T,
         revert_protection: bool,
     ) -> Result<String> {
-        let block_hash = self
-            .client
-            .get_recent_block_hash_v2(GetRecentBlockHashRequestV2 { offset: 0 })
-            .await?
-            .into_inner()
-            .block_hash;
-
         let keypair = self.get_keypair()?;
-        let signed_tx = sign_transaction(&tx, keypair, block_hash).await?;
+        let signed_tx = sign_transaction(&tx, keypair).await?;
 
         let paladin_request = api::PostSubmitPaladinRequest {
             transaction: Some(TransactionMessageV2 {

--- a/src/provider/http/mod.rs
+++ b/src/provider/http/mod.rs
@@ -10,7 +10,7 @@ use serde::de::DeserializeOwned;
 use serde_json::json;
 use crate::common::constants::WARNING_TLS_SLOWDOWN;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
-use solana_trader_proto::api::{self, PostSubmitPaladinRequest, GetRecentBlockHashResponseV2};
+use solana_trader_proto::api::{self, PostSubmitPaladinRequest};
 use crate::provider::utils::timestamp_rfc3339;
 
 use crate::{
@@ -108,20 +108,8 @@ impl HTTPClient {
     ) -> Result<Vec<String>> {
         let keypair = self.get_keypair()?;
 
-        // TODO: refactor once this endpoint is defined
-        let response = self
-            .client
-            .get(format!(
-                "{}/api/v2/system/blockhash?offset={}",
-                self.base_url, 0
-            ))
-            .send()
-            .await?;
-
-        let res: GetRecentBlockHashResponseV2 = self.handle_response(response).await?;
-
         if txs.len() == 1 {
-            let signed_tx = sign_transaction(&txs[0], keypair, res.block_hash).await?;
+            let signed_tx = sign_transaction(&txs[0], keypair).await?;
 
             let request_json = json!({
                 "transaction": { "content": signed_tx.content, "isCleanup": signed_tx.is_cleanup },
@@ -148,7 +136,7 @@ impl HTTPClient {
 
         let mut entries = Vec::with_capacity(txs.len());
         for tx in txs {
-            let signed_tx = sign_transaction(&tx, keypair, res.block_hash.clone()).await?;
+            let signed_tx = sign_transaction(&tx, keypair).await?;
             entries.push(json!({
                 "transaction": {
                     "content": signed_tx.content,
@@ -279,22 +267,10 @@ impl HTTPClient {
     ) -> Result<Vec<String>> {
         let keypair = self.get_keypair()?;
 
-        // Get recent blockhash
-        let response = self
-            .client
-            .get(format!(
-                "{}/api/v2/system/blockhash?offset={}",
-                self.base_url, 0
-            ))
-            .send()
-            .await?;
-
-        let res: GetRecentBlockHashResponseV2 = self.handle_response(response).await?;
-
         // Build entries for each transaction
         let mut entries = Vec::with_capacity(txs.len());
         for tx in txs {
-            let signed_tx = sign_transaction(&tx, keypair, res.block_hash.clone()).await?;
+            let signed_tx = sign_transaction(&tx, keypair).await?;
             entries.push(json!({
                 "transaction": {
                     "content": signed_tx.content,
@@ -401,18 +377,8 @@ impl HTTPClient {
         tx: T,
         revert_protection: bool,
     ) -> Result<String> {
-        let response = self
-            .client
-            .get(format!(
-                "{}/api/v2/system/blockhash?offset={}",
-                self.base_url, 0
-            ))
-            .send()
-            .await?;
-
-        let res: GetRecentBlockHashResponseV2 = self.handle_response(response).await?;
         let keypair = self.get_keypair()?;
-        let signed_tx = sign_transaction(&tx, keypair, res.block_hash).await?;
+        let signed_tx = sign_transaction(&tx, keypair).await?;
 
         let request_json = json!({
             "transaction": {

--- a/src/provider/ws/mod.rs
+++ b/src/provider/ws/mod.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use serde_json::json;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
-use solana_trader_proto::api::{self, PostSubmitPaladinRequest, GetRecentBlockHashResponseV2};
+use solana_trader_proto::api::{self, PostSubmitPaladinRequest};
 
 use crate::common::signing::{sign_transaction, SubmitParams};
 use crate::common::{get_base_url_from_env, is_submit_only_endpoint, ws_endpoint, BaseConfig};
@@ -69,11 +69,8 @@ impl WebSocketClient {
     ) -> Result<Vec<String>> {
         let keypair = self.get_keypair()?;
 
-        let hash_res: GetRecentBlockHashResponseV2 =
-            self.conn.request("GetRecentBlockHashV2", json!({})).await?;
-
         if txs.len() == 1 {
-            let signed_tx = sign_transaction(&txs[0], keypair, hash_res.block_hash).await?;
+            let signed_tx = sign_transaction(&txs[0], keypair).await?;
 
             let request = json!({
                 "transaction": {
@@ -97,7 +94,7 @@ impl WebSocketClient {
 
         let mut entries = Vec::with_capacity(txs.len());
         for tx in txs {
-            let signed_tx = sign_transaction(&tx, keypair, hash_res.block_hash.clone()).await?;
+            let signed_tx = sign_transaction(&tx, keypair).await?;
             entries.push(json!({
                 "transaction": {
                     "content": signed_tx.content,
@@ -136,13 +133,10 @@ impl WebSocketClient {
     ) -> Result<Vec<String>> {
         let keypair = self.get_keypair()?;
 
-        let hash_res: GetRecentBlockHashResponseV2 =
-            self.conn.request("GetRecentBlockHashV2", json!({})).await?;
-
         // Build entries for each transaction
         let mut entries = Vec::with_capacity(txs.len());
         for tx in txs {
-            let signed_tx = sign_transaction(&tx, keypair, hash_res.block_hash.clone()).await?;
+            let signed_tx = sign_transaction(&tx, keypair).await?;
             entries.push(json!({
                 "transaction": {
                     "content": signed_tx.content,
@@ -176,11 +170,8 @@ impl WebSocketClient {
         tx: T,
         revert_protection: bool,
     ) -> Result<String> {
-        let hash_res: GetRecentBlockHashResponseV2 =
-            self.conn.request("GetRecentBlockHashV2", json!({})).await?;
-
         let keypair = self.get_keypair()?;
-        let signed_tx = sign_transaction(&tx, keypair, hash_res.block_hash).await?;
+        let signed_tx = sign_transaction(&tx, keypair).await?;
 
         let request = json!({
             "transaction": {


### PR DESCRIPTION
The signing now operates directly on the existing serialized transaction without reserializing the message, preserving transaction size and ordering assumptions (same as the Go-SDK). Corresponding updates remove obsolete parameters and redundant code across gRPC, HTTP, and WebSocket providers. Additionally, we now always attempt to decode and sign the transaction as a versioned transaction first, falling back to legacy on failure. This is a necessary change if we want to not reserialize the transaction since we cannot mutate it.